### PR TITLE
More changes to method docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 
 .coverage
 examples/*.gif
-example/Basic_Usage.ipynb
 dist/*
 build/*
 *.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 .coverage
 examples/*.gif
+example/Basic_Usage.ipynb
 dist/*
 build/*
 *.egg-info

--- a/MesoPy.py
+++ b/MesoPy.py
@@ -200,7 +200,7 @@ class Meso(object):
         country: string, optional
             Single or comma separated list of abbreviated 2 or 3 character countries e.g. country='us,ca,mx'
         radius: list, optional
-            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[-120,40,20]
+            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[40,-120,20]
         bbox: list, optional
             Stations within a [lon/lat] box in the order [lonmin,latmin,lonmax,latmax] e.g. bbox=[-120,40,-119,41]
         cwa: string, optional
@@ -267,7 +267,7 @@ class Meso(object):
         country: string, optional
             Single or comma separated list of abbreviated 2 or 3 character countries e.g. country='us,ca,mx'
         radius: list, optional
-            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[-120,40,20]
+            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[40,-120,20]
         bbox: list, optional
             Stations within a [lon/lat] box in the order [lonmin,latmin,lonmax,latmax] e.g. bbox=[-120,40,-119,41]
         cwa: string, optional
@@ -336,7 +336,7 @@ class Meso(object):
         country: string, optional
             Single or comma separated list of abbreviated 2 or 3 character countries e.g. country='us,ca,mx'
         radius: list, optional
-            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[-120,40,20]
+            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[40,-120,20]
         bbox: list, optional
             Stations within a [lon/lat] box in the order [lonmin,latmin,lonmax,latmax] e.g. bbox=[-120,40,-119,41]
         cwa: string, optional
@@ -405,7 +405,7 @@ class Meso(object):
         country: string, optional
             Single or comma separated list of abbreviated 2 or 3 character countries e.g. country='us,ca,mx'
         radius: list, optional
-            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[-120,40,20]
+            Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[40,-120,20]
         bbox: list, optional
             Stations within a [lon/lat] box in the order [lonmin,latmin,lonmax,latmax] e.g. bbox=[-120,40,-119,41]
         cwa: string, optional


### PR DESCRIPTION
Reversed the values for lat and lon in these lines:
Distance from a lat/lon pt as [lat,lon,radius (mi)]e.g. radius=[-120,40,20]

You can ignore the .gitignore changes. Just replace my MesoPy.py with yours. 
