### PR TITLE
Catch error for long (2+ year) date requests

### DIFF
--- a/MesoPy.py
+++ b/MesoPy.py
@@ -145,6 +145,9 @@ class Meso(object):
         """
         http_error = 'Could not connect to the API. This could be because you have no internet connection, a parameter' \
                      ' was input incorrectly, or the API is currently down. Please try again.'
+                     
+        json_error = 'Could not retrieve JSON values. Try again with a shorter date range.'
+        
         # For python 3.4
         try:
             qsp = urllib.parse.urlencode(request_dict, doseq=True)
@@ -159,7 +162,13 @@ class Meso(object):
                 raise MesoPyError(http_error)
         except urllib.error.URLError:
             raise MesoPyError(http_error)
-        return self._checkresponse(json.loads(resp.decode('utf-8')))
+        
+        try:
+            json_data = json.loads(resp.decode('utf-8'))
+        except ValueError:
+            raise MesoPyError(json_error)
+        
+        return self._checkresponse(json_data)
 
     def _check_geo_param(self, arg_list):
         r""" Checks each function call to make sure that the user has provided at least one of the following geographic


### PR DESCRIPTION
This PR catches JSON errors, often caused by long date range requests. See #21 